### PR TITLE
improvement: expose the provider of gitlab, bitbucket, and github (usefu...

### DIFF
--- a/lib/git-issues/providers/bitbucket.rb
+++ b/lib/git-issues/providers/bitbucket.rb
@@ -38,6 +38,10 @@ class RepoProvider::Bitbucket
     bitbucket.issues.delete( repo['user'], repo['repo'], id)
   end
 
+  def provider
+    bitbucket
+  end
+
   private
 
   def format_issues is

--- a/lib/git-issues/providers/github.rb
+++ b/lib/git-issues/providers/github.rb
@@ -31,6 +31,10 @@ class RepoProvider::Github
     log.warn "You can't delete issues on GitHub. Please close/resolve them instead."
   end
 
+  def provider
+    github
+  end
+
   private
 
   def gh_repo

--- a/lib/git-issues/providers/gitlab.rb
+++ b/lib/git-issues/providers/gitlab.rb
@@ -30,6 +30,10 @@ class RepoProvider::Gitlab
     log.warn "You can't delete issues on Gitlab anymore, it is deprecated. Please close/resolve them instead."
   end
 
+  def provider
+    gitlab
+  end
+
   private
 
   def gl_project_id


### PR DESCRIPTION
...l on cli)

this way you can do:

```
git issues cli
repo.provider
```

and get low-level access to the object

Signed-off-by: Dominik Richter dominik.richter@gmail.com
